### PR TITLE
[#86e1ar30g] Add heartbeatDebounce option to analytics plugin

### DIFF
--- a/packages/client-sdk-core/src/plugin/analytics.js
+++ b/packages/client-sdk-core/src/plugin/analytics.js
@@ -150,6 +150,7 @@ class Analytics {
     this._startAt = undefined;
     this._loadingAt = undefined;
     this._readyAt = undefined;
+    this._heartbeatTimer = undefined;
 
     this.config();
 
@@ -207,6 +208,16 @@ class Analytics {
   }
 
   _sendHeartbeat() {
+    const debounce = this._plugin._options?.heartbeatDebounce;
+    if (debounce) {
+      clearTimeout(this._heartbeatTimer);
+      this._heartbeatTimer = setTimeout(() => this._doSendHeartbeat(), debounce);
+    } else {
+      this._doSendHeartbeat();
+    }
+  }
+
+  _doSendHeartbeat() {
     const tracker = this._workflow.trackers.container;
     tracker && tracker.heartbeat();
   }

--- a/packages/client-sdk-core/src/plugin/analytics.js
+++ b/packages/client-sdk-core/src/plugin/analytics.js
@@ -151,6 +151,7 @@ class Analytics {
     this._loadingAt = undefined;
     this._readyAt = undefined;
     this._heartbeatTimer = undefined;
+    this._heartbeatTrailingTimer = undefined;
 
     this.config();
 
@@ -208,10 +209,24 @@ class Analytics {
   }
 
   _sendHeartbeat() {
-    const debounce = this._plugin._options?.heartbeatDebounce;
-    if (debounce) {
-      clearTimeout(this._heartbeatTimer);
-      this._heartbeatTimer = setTimeout(() => this._doSendHeartbeat(), debounce);
+    const throttle = this._plugin._options?.heartbeatThrottle;
+    if (throttle) {
+      if (!this._heartbeatTimer) {
+        // Leading edge: fire immediately, cancel any stale trailing timer, start cooldown
+        clearTimeout(this._heartbeatTrailingTimer);
+        this._heartbeatTrailingTimer = undefined;
+        this._doSendHeartbeat();
+        this._heartbeatTimer = setTimeout(() => {
+          this._heartbeatTimer = undefined;
+        }, throttle);
+      } else {
+        // During cooldown: debounce a trailing fire so the last call always goes out
+        clearTimeout(this._heartbeatTrailingTimer);
+        this._heartbeatTrailingTimer = setTimeout(() => {
+          this._heartbeatTrailingTimer = undefined;
+          this._doSendHeartbeat();
+        }, throttle);
+      }
     } else {
       this._doSendHeartbeat();
     }


### PR DESCRIPTION
Multiple heartbeat triggers can fire within milliseconds of each other during a single user action (activity click, session transition, ready state). Add an opt-in heartbeatDebounce option (ms) that collapses rapid consecutive _sendHeartbeat calls into a single trailing send.

Configurable via: client.plugins.use('std:analytics', { heartbeatDebounce: 500 }) No default — existing customers are unaffected.