### PR TITLE
fix(ui): merge facet filters per field; support aliased and hierarchical facets

### DIFF
--- a/packages/client-sdk-ui/package.json
+++ b/packages/client-sdk-ui/package.json
@@ -12,6 +12,7 @@
     "access": "public"
   },
   "scripts": {
+    "test": "npx uvu test",
     "build:clean": "npx rimraf dist",
     "build:cjs": "BABEL_ENV=cjs npx babel src --root-mode upward --out-dir dist/cjs",
     "build": "npm run build:clean && npm run build:cjs"

--- a/packages/client-sdk-ui/src/actor/filters.js
+++ b/packages/client-sdk-ui/src/actor/filters.js
@@ -12,10 +12,10 @@ function mergeState(state = {}, update = {}) {
   }));
 }
 
-function optionsToState({ sort } = {}) {
-  // TODO: facets
+function optionsToState({ sort, facets } = {}) {
   return trimObj({
-    facets: Object.freeze({}),
+    // `facets.initial` lets a page start with filters already applied.
+    facets: Object.freeze({ ...((facets && facets.initial) || {}) }),
     sort: sortOptionsToState(sort),
   });
 }
@@ -62,7 +62,12 @@ export default class Filters {
 
   update(updates) {
     const oldStates = this._getStates();
-    this._states = mergeState({ ...oldStates, ...updates });
+    // mergeState takes (state, update) and merges `facets` per field. Passing a
+    // single pre-spread object made that per-field merge a no-op, so updating
+    // one field dropped every other active filter — including via
+    // Facets._unselect, which sets one field to undefined and relies on the
+    // rest surviving. To clear a field, pass { [field]: undefined }.
+    this._states = mergeState(oldStates, updates);
     const states = this._getStates();
     this._events.emit('update', { updates, states, oldStates });
   }
@@ -99,7 +104,18 @@ class Facets {
 
   constructor(filters, options = {}) {
     this._filters = filters;
-    this._options = options;
+    this._fallbackOptions = options;
+  }
+
+  // Read live, so useFilters({ facets: { multivalued: true } }) takes effect.
+  // Previously this was a constructor argument and Filters was always built as
+  // `new Filters(views)`, so the option could not be set by any public path.
+  // A method rather than a getter: the production build runs terser with
+  // pure_getters, which is free to assume getters have no side effects.
+  _getOptions() {
+    const views = this._filters && this._filters._views;
+    const resolved = views && views._options && views._options.resolved.filters;
+    return (resolved && resolved.facets) || this._fallbackOptions || {};
   }
 
   isSelected(field, value) {
@@ -133,7 +149,7 @@ class Facets {
   }
 
   _select(field, value) {
-    const values = this._options.multivalued ? [...this._getFieldValues(field), value] : [value];
+    const values = this._getOptions().multivalued ? [...this._getFieldValues(field), value] : [value];
     values.sort();
     this._filters.update({ facets: { [field]: values } });
   }

--- a/packages/client-sdk-ui/src/actor/filters.js
+++ b/packages/client-sdk-ui/src/actor/filters.js
@@ -122,11 +122,11 @@ class Facets {
     return this._getFieldValues(field).includes(value);
   }
 
-  select(field, value) {
+  select(field, value, options) {
     if (this.isSelected(field, value)) {
       return;
     }
-    this._select(field, value);
+    this._select(field, value, options);
   }
 
   unselect(field, value) {
@@ -136,11 +136,13 @@ class Facets {
     this._unselect(field, value);
   }
 
-  toggle(field, value) {
+  // `options.multivalued` overrides the workflow-level setting for this call, so
+  // one facet can allow several values while another is single-choice.
+  toggle(field, value, options) {
     if (this.isSelected(field, value)) {
       this._unselect(field, value);
     } else {
-      this._select(field, value);
+      this._select(field, value, options);
     }
   }
 
@@ -148,8 +150,9 @@ class Facets {
     return this._filters._getStates().facets[field] || [];
   }
 
-  _select(field, value) {
-    const values = this._getOptions().multivalued ? [...this._getFieldValues(field), value] : [value];
+  _select(field, value, { multivalued } = {}) {
+    const multi = multivalued !== undefined ? multivalued : this._getOptions().multivalued;
+    const values = multi ? [...this._getFieldValues(field), value] : [value];
     values.sort();
     this._filters.update({ facets: { [field]: values } });
   }

--- a/packages/client-sdk-ui/src/element/container/miso-container.js
+++ b/packages/client-sdk-ui/src/element/container/miso-container.js
@@ -62,6 +62,11 @@ export default class MisoContainerElement extends MisoStubElement {
   }
 
   set workflow(workflow) {
+    // An explicit assignment wins over the default this container would pick up
+    // on connect. Without this, several searches on one page are not possible:
+    // connectedCallback awaits the client and then overwrites whatever was
+    // assigned, so every container ends up on whichever client resolved first.
+    this._workflowAssigned = workflow !== undefined;
     this._setWorkflow(workflow);
   }
 
@@ -86,13 +91,19 @@ export default class MisoContainerElement extends MisoStubElement {
     super.connectedCallback();
     const client = this._client = await getClient(MisoContainerElement);
     if (document.body.contains(this)) { // in case already disconnected
-      this._setWorkflow(this._getWorkflow(client));
+      if (!this._workflowAssigned) {
+        this._setWorkflow(this._getWorkflow(client));
+      }
       this._onConnected(client);
     }
   }
 
   disconnectedCallback() {
+    // Keep the explicit assignment flag: a container that is moved or
+    // re-attached should return to the workflow it was given, not the default.
+    const assigned = this._workflowAssigned;
     this._setWorkflow(undefined);
+    this._workflowAssigned = assigned;
     super.disconnectedCallback();
   }
 

--- a/packages/client-sdk-ui/src/layout/input/facets.js
+++ b/packages/client-sdk-ui/src/layout/input/facets.js
@@ -112,6 +112,10 @@ function options(layout, facet, state) {
   const separator =
     (hierarchy && hierarchy.separator) || (definition && definition.separator) || DEFAULT_HIERARCHY_SEPARATOR;
   const pathValues = !!(hierarchy || (definition && definition.separator));
+  // 'single' means picking a value replaces the previous one on that field;
+  // 'multiple' adds to it. Unset falls back to the workflow-level setting.
+  const single = definition && definition.select === 'single';
+  const alias = facet.alias || field;
 
   const rows = entries.map(([value, count]) => {
     // Children of this row come from the facet one level down, matched on the
@@ -120,15 +124,15 @@ function options(layout, facet, state) {
     const kids = hierarchy && children
       ? children.filter(([childValue]) => childValue.startsWith(value + separator))
       : undefined;
-    return templates.option(layout, { field, value, count, hierarchy, separator, pathValues, children: kids }, state);
+    return templates.option(layout, { field, value, count, hierarchy, separator, pathValues, single, alias, children: kids }, state);
   }).join('');
 
   return `<ul class="${facetClassName}__options" data-role="options">${rows}</ul>`;
 }
 
 function option(layout, entry, state) {
-  const { facetClassName = DEDAULT_FACET_CLASSNAME, templates } = layout;
-  const { children, hierarchy, separator, pathValues, field } = entry;
+  const { facetClassName = DEDAULT_FACET_CLASSNAME, checkbox = false, templates } = layout;
+  const { children, hierarchy, separator, pathValues, field, alias, single } = entry;
   const hasChildren = !!(children && children.length);
 
   // The toggle sits outside the clickable option row, so expanding a branch
@@ -139,7 +143,7 @@ function option(layout, entry, state) {
 
   const nested = hasChildren
     ? `<ul class="${facetClassName}__children">${children.map(([value, count]) =>
-        templates.option(layout, { field, value, count, hierarchy, separator, pathValues: true }, state)).join('')}</ul>`
+        templates.option(layout, { field, value, count, hierarchy, separator, pathValues: true, single, alias }, state)).join('')}</ul>`
     : '';
 
   return `
@@ -147,6 +151,7 @@ function option(layout, entry, state) {
   <div class="${facetClassName}__row">
     ${toggle}
     <span class="${facetClassName}__option" data-role="option" tabindex="0" data-value="${escapeHtml(entry.value)}">
+      ${checkbox ? `<input type="${single ? 'radio' : 'checkbox'}"${single ? ` name="${escapeHtml(alias || field)}"` : ''} class="${facetClassName}__checkbox" data-role="checkbox" tabindex="-1">` : ''}
       <span class="${facetClassName}__value">${templates.value(layout, entry, state)}</span>
       <span class="${facetClassName}__count">${templates.count(layout, entry, state)}</span>
     </span>
@@ -203,11 +208,17 @@ export default class FacetsLayout extends TemplateBasedLayout {
     return DEFAULT_CLASSNAME;
   }
 
-  constructor({ className = DEFAULT_CLASSNAME, templates, ...options } = {}) {
+  constructor({ className = DEFAULT_CLASSNAME, facetClassName, checkbox = false, templates, ...options } = {}) {
     super({
       className,
       templates: { ...DEFAULT_TEMPLATES, ...templates },
       ...options,
+    });
+    // The base layout keeps only className and templates, so options the
+    // templates read have to be held here or they are silently dropped.
+    Object.defineProperties(this, {
+      checkbox: { value: checkbox, enumerable: true },
+      facetClassName: { value: facetClassName || DEDAULT_FACET_CLASSNAME, enumerable: true },
     });
     this._bindings = new Bindings();
   }
@@ -261,6 +272,12 @@ export default class FacetsLayout extends TemplateBasedLayout {
     } else {
       element.classList.remove('selected');
     }
+    // The filter state is the source of truth, not the input's own toggling: a
+    // click flips the box, and this puts it back in step with what was applied.
+    const box = element.querySelector(`[data-role="checkbox"]`);
+    if (box) {
+      box.checked = !!selected;
+    }
   }
 
   _syncBindings(element, state) {
@@ -278,6 +295,7 @@ export default class FacetsLayout extends TemplateBasedLayout {
       if (!field) {
         continue;
       }
+      const key = facetElement.getAttribute('data-key') || field;
       for (const itemElement of this._getItemElements(facetElement)) {
         // Read the value off the element rather than pairing by position. A
         // nested tree interleaves parents and children in the DOM, so index
@@ -287,7 +305,7 @@ export default class FacetsLayout extends TemplateBasedLayout {
           continue;
         }
         keys.push(getItemKey(field, value));
-        values.push({ field, value });
+        values.push({ field, value, key });
         elements.push(itemElement);
       }
     }
@@ -344,8 +362,11 @@ export default class FacetsLayout extends TemplateBasedLayout {
     if (!option) {
       return;
     }
-    const { field, value } = option;
-    this._view.filters.facets.toggle(field, value);
+    const { field, value, key } = option;
+    const definition = facetDefinitions(this)[key];
+    const select = definition && definition.select;
+    this._view.filters.facets.toggle(field, value,
+      select ? { multivalued: select !== 'single' } : undefined);
     this._view.filters.apply(); // TODO: support autoApply = false
   }
 

--- a/packages/client-sdk-ui/src/layout/input/facets.js
+++ b/packages/client-sdk-ui/src/layout/input/facets.js
@@ -7,6 +7,40 @@ const TYPE = 'facets';
 const DEFAULT_CLASSNAME = 'miso-facets';
 const DEDAULT_FACET_CLASSNAME = 'miso-facet';
 const CUSTOM_ATTRIBUTES_PREFIX = 'custom_attributes.';
+const DEFAULT_HIERARCHY_SEPARATOR = ':::';
+
+// The response keys facet_fields by ALIAS, while filtering must use the real
+// FIELD. Read the definitions the page already declared in useApi({facets}) so
+// both are known here, instead of assuming key === field.
+function facetDefinitions(layout) {
+  const view = layout._view;
+  // useApi({ facets: [...] }) is normalized into api.payload.facets.
+  const api = (view && view.workflowOptions && view.workflowOptions.api) || {};
+  const payload = api.payload || {};
+  const definitions = {};
+  for (const definition of payload.facets || []) {
+    if (typeof definition === 'string') {
+      definitions[definition] = { field: definition, alias: definition };
+    } else {
+      const alias = definition.alias || definition.field;
+      definitions[alias] = { ...definition, alias, field: definition.field };
+    }
+  }
+  return definitions;
+}
+
+// A definition may declare that its values are hierarchical paths, and name a
+// second facet holding the level below it:
+//   { field: 'category_path_depth_1', alias: 'cat_top',
+//     hierarchy: { childrenAlias: 'cat_top_l2', separator: ':::' } }
+function hierarchyOf(definition) {
+  return (definition && definition.hierarchy) || undefined;
+}
+
+function leafOf(value, separator) {
+  const parts = value.split(separator);
+  return parts[parts.length - 1];
+}
 
 function root(layout, state) {
   const { className, role, templates } = layout;
@@ -17,13 +51,40 @@ function root(layout, state) {
 function facets(layout, state) {
   const { templates } = layout;
   const { facet_fields = {} } = state.value || {};
-  return Object.keys(facet_fields).map(field => templates.facet(layout, { field, entries: facet_fields[field] }, state)).join('');
+  const definitions = facetDefinitions(layout);
+
+  // An alias that only supplies the child level of another facet is rendered
+  // inside its parent, not as a box of its own.
+  const childAliases = new Set();
+  for (const alias in definitions) {
+    const hierarchy = hierarchyOf(definitions[alias]);
+    if (hierarchy && hierarchy.childrenAlias) {
+      childAliases.add(hierarchy.childrenAlias);
+    }
+  }
+
+  return Object.keys(facet_fields)
+    .filter(alias => !childAliases.has(alias))
+    .map(alias => {
+      const definition = definitions[alias] || { field: alias, alias };
+      return templates.facet(layout, {
+        alias,
+        field: definition.field || alias,
+        name: definition.name,
+        definition,
+        entries: facet_fields[alias],
+        children: (hierarchyOf(definition) && facet_fields[hierarchyOf(definition).childrenAlias]) || undefined,
+      }, state);
+    })
+    .join('');
 }
 
 function facet(layout, facet, state) {
   const { facetClassName = DEDAULT_FACET_CLASSNAME, templates } = layout;
-  const { field } = facet;
-  return `<div class="${facetClassName}" data-role="facet" data-field="${escapeHtml(field)}">${templates.header(layout, facet, state)}${templates.options(layout, facet, state)}</div>`;
+  const { field, alias = field } = facet;
+  // data-key is the response key, used to bind values to elements.
+  // data-field is the index field, used when a click becomes a filter.
+  return `<div class="${facetClassName}" data-role="facet" data-key="${escapeHtml(alias)}" data-field="${escapeHtml(field)}">${templates.header(layout, facet, state)}${templates.options(layout, facet, state)}</div>`;
 }
 
 function header(layout, facet, state) {
@@ -31,7 +92,10 @@ function header(layout, facet, state) {
   return `<div class="${facetClassName}__header">${templates.title(layout, facet, state)}</div>`;
 }
 
-function title(layout, { field }) {
+function title(layout, { field, name }) {
+  if (name) {
+    return escapeHtml(name);
+  }
   if (field.startsWith(CUSTOM_ATTRIBUTES_PREFIX)) {
     field = field.substring(CUSTOM_ATTRIBUTES_PREFIX.length);
   }
@@ -39,23 +103,58 @@ function title(layout, { field }) {
   return escapeHtml(field);
 }
 
-function options(layout, { field, entries }, state) {
+function options(layout, facet, state) {
   const { facetClassName = DEDAULT_FACET_CLASSNAME, templates } = layout;
-  return `<ul class="${facetClassName}__options" data-role="options">${entries.map(([value, count]) => templates.option(layout, { field, value, count }, state)).join('')}</ul>`;
+  const { field, entries = [], children, definition } = facet;
+  const hierarchy = hierarchyOf(definition);
+  const separator = (hierarchy && hierarchy.separator) || DEFAULT_HIERARCHY_SEPARATOR;
+
+  const rows = entries.map(([value, count]) => {
+    // Children of this row come from the facet one level down, matched on the
+    // parent path. The level itself is guaranteed by the depth field, so no
+    // pattern has to express it.
+    const kids = hierarchy && children
+      ? children.filter(([childValue]) => childValue.startsWith(value + separator))
+      : undefined;
+    return templates.option(layout, { field, value, count, hierarchy, separator, children: kids }, state);
+  }).join('');
+
+  return `<ul class="${facetClassName}__options" data-role="options">${rows}</ul>`;
 }
 
 function option(layout, entry, state) {
   const { facetClassName = DEDAULT_FACET_CLASSNAME, templates } = layout;
+  const { children, hierarchy, separator, field } = entry;
+  const hasChildren = !!(children && children.length);
+
+  // The toggle sits outside the clickable option row, so expanding a branch
+  // does not also select it.
+  const toggle = hasChildren
+    ? `<span class="${facetClassName}__toggle" data-role="toggle"></span>`
+    : `<span class="${facetClassName}__toggle-spacer"></span>`;
+
+  const nested = hasChildren
+    ? `<ul class="${facetClassName}__children">${children.map(([value, count]) =>
+        templates.option(layout, { field, value, count, hierarchy, separator }, state)).join('')}</ul>`
+    : '';
+
   return `
-<li class="${facetClassName}__option" data-role="option" tabindex="0">
-  <span class="${facetClassName}__value">${templates.value(layout, entry, state)}</span>
-  <span class="${facetClassName}__count">${templates.count(layout, entry, state)}</span>
+<li class="${facetClassName}__item"${hasChildren ? ' data-expanded="false"' : ''}>
+  <div class="${facetClassName}__row">
+    ${toggle}
+    <span class="${facetClassName}__option" data-role="option" tabindex="0" data-value="${escapeHtml(entry.value)}">
+      <span class="${facetClassName}__value">${templates.value(layout, entry, state)}</span>
+      <span class="${facetClassName}__count">${templates.count(layout, entry, state)}</span>
+    </span>
+  </div>
+  ${nested}
 </li>`;
 }
 
 
-function value(layout, { value }, state) {
-  return escapeHtml(value);
+function value(layout, { value, hierarchy, separator }, state) {
+  // Under a heading that already names the branch, the leaf is the useful label.
+  return escapeHtml(hierarchy ? leafOf(value, separator || DEFAULT_HIERARCHY_SEPARATOR) : value);
 }
 
 function count(layout, { count }, state) {
@@ -164,22 +263,24 @@ export default class FacetsLayout extends TemplateBasedLayout {
     if (!element || !state.value) {
       return;
     }
-    const items = this._getItems(state);
     const keys = [];
     const values = [];
     const elements = [];
     for (const facetElement of this._getFacetElements(element)) {
+      // The FIELD, not the response key: a click has to become a filter on the
+      // real index field even when several facets share one field under
+      // different aliases.
       const field = facetElement.getAttribute('data-field');
-      const _values = items[field];
-      if (!_values) {
+      if (!field) {
         continue;
       }
-      const itemElements = this._getItemElements(facetElement);
-      for (let i = 0; i < itemElements.length; i++) {
-        const itemElement = itemElements[i];
-        const value = _values[i];
+      for (const itemElement of this._getItemElements(facetElement)) {
+        // Read the value off the element rather than pairing by position. A
+        // nested tree interleaves parents and children in the DOM, so index
+        // pairing against a flat list of values would bind the wrong rows.
+        const value = itemElement.getAttribute('data-value');
         if (!value) {
-          break;
+          continue;
         }
         keys.push(getItemKey(field, value));
         values.push({ field, value });
@@ -218,6 +319,16 @@ export default class FacetsLayout extends TemplateBasedLayout {
   _handleClick(event) {
     // only left click
     if (event.button !== 0) {
+      return;
+    }
+    // Expanding a branch changes what is visible, not what is selected.
+    const toggle = event.target.closest(`[data-role="toggle"]`);
+    if (toggle) {
+      const item = toggle.closest(`.${this.facetClassName || DEDAULT_FACET_CLASSNAME}__item`);
+      if (item) {
+        const expanded = item.getAttribute('data-expanded') === 'true';
+        item.setAttribute('data-expanded', expanded ? 'false' : 'true');
+      }
       return;
     }
     const element = event.target.closest(`[data-role="option"]`);

--- a/packages/client-sdk-ui/src/layout/input/facets.js
+++ b/packages/client-sdk-ui/src/layout/input/facets.js
@@ -107,7 +107,11 @@ function options(layout, facet, state) {
   const { facetClassName = DEDAULT_FACET_CLASSNAME, templates } = layout;
   const { field, entries = [], children, definition } = facet;
   const hierarchy = hierarchyOf(definition);
-  const separator = (hierarchy && hierarchy.separator) || DEFAULT_HIERARCHY_SEPARATOR;
+  // `separator` may be declared on its own, for a facet whose values are paths
+  // but which is not rendered as a tree. Both cases want the leaf as the label.
+  const separator =
+    (hierarchy && hierarchy.separator) || (definition && definition.separator) || DEFAULT_HIERARCHY_SEPARATOR;
+  const pathValues = !!(hierarchy || (definition && definition.separator));
 
   const rows = entries.map(([value, count]) => {
     // Children of this row come from the facet one level down, matched on the
@@ -116,7 +120,7 @@ function options(layout, facet, state) {
     const kids = hierarchy && children
       ? children.filter(([childValue]) => childValue.startsWith(value + separator))
       : undefined;
-    return templates.option(layout, { field, value, count, hierarchy, separator, children: kids }, state);
+    return templates.option(layout, { field, value, count, hierarchy, separator, pathValues, children: kids }, state);
   }).join('');
 
   return `<ul class="${facetClassName}__options" data-role="options">${rows}</ul>`;
@@ -124,7 +128,7 @@ function options(layout, facet, state) {
 
 function option(layout, entry, state) {
   const { facetClassName = DEDAULT_FACET_CLASSNAME, templates } = layout;
-  const { children, hierarchy, separator, field } = entry;
+  const { children, hierarchy, separator, pathValues, field } = entry;
   const hasChildren = !!(children && children.length);
 
   // The toggle sits outside the clickable option row, so expanding a branch
@@ -135,7 +139,7 @@ function option(layout, entry, state) {
 
   const nested = hasChildren
     ? `<ul class="${facetClassName}__children">${children.map(([value, count]) =>
-        templates.option(layout, { field, value, count, hierarchy, separator }, state)).join('')}</ul>`
+        templates.option(layout, { field, value, count, hierarchy, separator, pathValues: true }, state)).join('')}</ul>`
     : '';
 
   return `
@@ -152,9 +156,9 @@ function option(layout, entry, state) {
 }
 
 
-function value(layout, { value, hierarchy, separator }, state) {
+function value(layout, { value, pathValues, separator }, state) {
   // Under a heading that already names the branch, the leaf is the useful label.
-  return escapeHtml(hierarchy ? leafOf(value, separator || DEFAULT_HIERARCHY_SEPARATOR) : value);
+  return escapeHtml(pathValues ? leafOf(value, separator || DEFAULT_HIERARCHY_SEPARATOR) : value);
 }
 
 function count(layout, { count }, state) {

--- a/packages/client-sdk-ui/src/layout/input/facets.js
+++ b/packages/client-sdk-ui/src/layout/input/facets.js
@@ -29,10 +29,21 @@ function facetDefinitions(layout) {
   return definitions;
 }
 
-// A definition may declare that its values are hierarchical paths, and name a
-// second facet holding the level below it:
-//   { field: 'category_path_depth_1', alias: 'cat_top',
-//     hierarchy: { childrenAlias: 'cat_top_l2', separator: ':::' } }
+// A definition may declare that its values are hierarchical paths. Two shapes:
+//
+//   one field holding EVERY ancestor path (recommended) — both levels come from
+//   the same facet and are split here by depth:
+//     { field: 'custom_attributes.category_paths', alias: 'cat_top',
+//       branch: null, hierarchy: { levels: 2, separator: ':::' } }
+//
+//   or one facet per level, naming the facet that holds the level below:
+//     { field: 'category_path_depth_1', alias: 'cat_top',
+//       hierarchy: { childrenAlias: 'cat_top_l2', separator: ':::' } }
+//
+// Prefer the first. Splitting a category tree across several fields means the
+// filters land in several facet_filters entries, which AND rather than OR, and
+// the engine's same-field exclusion no longer covers the whole dimension — so
+// picking a value at one level distorts the counts shown at another.
 function hierarchyOf(definition) {
   return (definition && definition.hierarchy) || undefined;
 }
@@ -40,6 +51,12 @@ function hierarchyOf(definition) {
 function leafOf(value, separator) {
   const parts = value.split(separator);
   return parts[parts.length - 1];
+}
+
+// How many levels below `branch` a value sits. A direct child is 1.
+function relativeDepth(value, branch, separator) {
+  const base = branch ? branch.split(separator).length : 0;
+  return value.split(separator).length - base;
 }
 
 function root(layout, state) {
@@ -117,12 +134,22 @@ function options(layout, facet, state) {
   const single = definition && definition.select === 'single';
   const alias = facet.alias || field;
 
-  const rows = entries.map(([value, count]) => {
-    // Children of this row come from the facet one level down, matched on the
-    // parent path. The level itself is guaranteed by the depth field, so no
-    // pattern has to express it.
-    const kids = hierarchy && children
-      ? children.filter(([childValue]) => childValue.startsWith(value + separator))
+  const branch = (definition && definition.branch) || undefined;
+
+  // With one field holding every level, the facet returns the whole subtree and
+  // the levels are separated here. With one facet per level, `children` carries
+  // the level below. Either way `rows` ends up as the direct children only.
+  const singleField = !!(hierarchy && !hierarchy.childrenAlias);
+  const rowEntries = singleField
+    ? entries.filter(([v]) => relativeDepth(v, branch, separator) === 1)
+    : entries;
+  const childEntries = singleField
+    ? entries.filter(([v]) => relativeDepth(v, branch, separator) === 2)
+    : children;
+
+  const rows = rowEntries.map(([value, count]) => {
+    const kids = hierarchy && childEntries
+      ? childEntries.filter(([childValue]) => childValue.startsWith(value + separator))
       : undefined;
     return templates.option(layout, { field, value, count, hierarchy, separator, pathValues, single, alias, children: kids }, state);
   }).join('');

--- a/packages/client-sdk-ui/src/workflow/options/api.js
+++ b/packages/client-sdk-ui/src/workflow/options/api.js
@@ -17,6 +17,15 @@ export function normalizeApiOptions([name, payload] = []) {
   if ((name && typeof name !== 'string') || (payload !== undefined && typeof payload !== 'object')) {
     throw new Error(`Invalid arguments for useApi(): ${name}, ${payload}`);
   }
+  // useApi({ fl: [...] }) is the payload. Nesting it — useApi({ payload: {...} })
+  // — used to be accepted in silence and the inner keys never reached the API.
+  if (payload && typeof payload === 'object' && payload.payload && typeof payload.payload === 'object') {
+    console.warn(
+      `[miso] useApi(): a "payload" key was found inside the payload. Its contents ` +
+      `(${Object.keys(payload.payload).join(', ')}) will be sent as a field named "payload" and ignored. ` +
+      `Pass these options at the top level, e.g. useApi({ fl: [...] }).`
+    );
+  }
   return trimObj({ group, name, payload });
 }
 

--- a/packages/client-sdk-ui/src/workflow/options/auto-query.js
+++ b/packages/client-sdk-ui/src/workflow/options/auto-query.js
@@ -6,6 +6,8 @@ import { ROLE, QUESTION_SOURCE } from '../../constants.js';
 export const DEFAULT_AUTO_QUERY_PARAM = 'q';
 export const DEFAULT_AUTO_QUERY_SOURCE_PARAM = 'qs';
 
+const KNOWN_AUTO_QUERY_OPTIONS = ['setValue', 'focus', 'updateUrl', 'param', 'sourceParam'];
+
 export function normalizeAutoQueryOptions({
   setValue = true,
   focus = true,
@@ -14,6 +16,15 @@ export function normalizeAutoQueryOptions({
   sourceParam = DEFAULT_AUTO_QUERY_SOURCE_PARAM,
   ...options
 } = {}) {
+  // autoQuery takes OPTIONS, not a query. autoQuery({ q: 'shoes' }) used to be
+  // accepted in silence: the page rendered and no request was ever made. Say so.
+  const unknown = Object.keys(options).filter(key => !KNOWN_AUTO_QUERY_OPTIONS.includes(key));
+  if (unknown.length) {
+    const hint = unknown.includes('q')
+      ? ` To run a query, use workflow.query({ q: … }); autoQuery() reads it from the ?${param} parameter.`
+      : '';
+    console.warn(`[miso] autoQuery(): unknown option(s) ${unknown.map(k => `"${k}"`).join(', ')}, ignored.` + hint);
+  }
   return { setValue, focus, updateUrl, param, sourceParam, ...options };
 }
 

--- a/packages/client-sdk-ui/test/filters.js
+++ b/packages/client-sdk-ui/test/filters.js
@@ -1,0 +1,106 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+
+import Filters from '../src/actor/filters.js';
+import * as fields from '../src/actor/fields.js';
+
+// Minimal stand-in for the views actor: Filters only needs a hub to write the
+// resolved state into, an options object to read, and an error sink.
+function createViews(filtersOptions = {}) {
+  const written = {};
+  return {
+    _hub: {
+      update(field, states) {
+        written[field] = states;
+      },
+    },
+    _options: {
+      on() {
+        return () => {};
+      },
+      resolved: { filters: filtersOptions },
+    },
+    _error(error) {
+      throw error;
+    },
+    written,
+  };
+}
+
+function appliedFacets(views, filters) {
+  filters.apply({ silent: true });
+  const states = views.written[fields.filters()];
+  return (states && states.facets) || {};
+}
+
+test('update() merges facets per field instead of replacing the map', () => {
+  const views = createViews();
+  const filters = new Filters(views);
+
+  filters.update({ facets: { type: ['User guides'] } });
+  filters.update({ facets: { category_path_depth_1: ['Editorial'] } });
+
+  const facets = appliedFacets(views, filters);
+  assert.equal(facets.type, ['User guides'], 'the first field must survive the second update');
+  assert.equal(facets.category_path_depth_1, ['Editorial']);
+});
+
+test('update() clears one field with undefined and leaves the others alone', () => {
+  const views = createViews();
+  const filters = new Filters(views);
+
+  filters.update({ facets: { type: ['User guides'], category_path_depth_1: ['Editorial'] } });
+  filters.update({ facets: { type: undefined } });
+
+  const facets = appliedFacets(views, filters);
+  assert.not.ok(facets.type, 'the field set to undefined must be gone');
+  assert.equal(facets.category_path_depth_1, ['Editorial'], 'the other field must remain');
+});
+
+test('facets.unselect() does not drop filters on other fields', () => {
+  const views = createViews();
+  const filters = new Filters(views);
+
+  filters.update({ facets: { type: ['User guides'], category_path_depth_1: ['Editorial'] } });
+  filters.facets.unselect('category_path_depth_1', 'Editorial');
+
+  const facets = appliedFacets(views, filters);
+  assert.equal(facets.type, ['User guides'], 'unselecting one facet must not clear another field');
+  assert.not.ok(facets.category_path_depth_1);
+});
+
+test('facets.toggle() across two fields keeps both selections', () => {
+  const views = createViews();
+  const filters = new Filters(views);
+
+  filters.facets.toggle('category_path_depth_1', 'Editorial');
+  filters.facets.toggle('type', 'User guides');
+
+  const facets = appliedFacets(views, filters);
+  assert.equal(facets.category_path_depth_1, ['Editorial']);
+  assert.equal(facets.type, ['User guides']);
+});
+
+test('facets options are reachable, so multivalued selection works', () => {
+  const views = createViews({ facets: { multivalued: true } });
+  const filters = new Filters(views);
+
+  filters.facets.select('type', 'User guides');
+  filters.facets.select('type', 'Release notes');
+
+  const facets = appliedFacets(views, filters);
+  assert.equal(facets.type, ['Release notes', 'User guides'], 'both values are kept, sorted');
+});
+
+test('without multivalued, selecting replaces the value on that field', () => {
+  const views = createViews();
+  const filters = new Filters(views);
+
+  filters.facets.select('type', 'User guides');
+  filters.facets.select('type', 'Release notes');
+
+  const facets = appliedFacets(views, filters);
+  assert.equal(facets.type, ['Release notes']);
+});
+
+test.run();

--- a/packages/client-sdk-ui/test/filters.js
+++ b/packages/client-sdk-ui/test/filters.js
@@ -103,4 +103,28 @@ test('without multivalued, selecting replaces the value on that field', () => {
   assert.equal(facets.type, ['Release notes']);
 });
 
+test('facets.toggle() honours a per-call multivalued override', () => {
+  const views = createViews();                       // workflow default: single
+  const filters = new Filters(views);
+
+  filters.facets.toggle('category_path_depth_1', 'Editorial', { multivalued: true });
+  filters.facets.toggle('category_path_depth_1', 'Access rules', { multivalued: true });
+
+  const facets = appliedFacets(views, filters);
+  assert.equal(facets.category_path_depth_1, ['Access rules', 'Editorial'],
+    'a facet may allow several values even when the workflow default is single');
+});
+
+test('a per-call override of false keeps a facet single-choice', () => {
+  const views = createViews({ facets: { multivalued: true } });   // workflow default: multi
+  const filters = new Filters(views);
+
+  filters.facets.toggle('type', 'User guides', { multivalued: false });
+  filters.facets.toggle('type', 'Release notes', { multivalued: false });
+
+  const facets = appliedFacets(views, filters);
+  assert.equal(facets.type, ['Release notes'],
+    'the second pick replaces the first on a single-choice facet');
+});
+
 test.run();


### PR DESCRIPTION
## Why

Building a category-tree facet UI for a publisher surfaced five gaps. **One is a correctness bug that affects any page with more than one facet field**, hierarchy or not — it is the reason for opening this now, and it stands alone if the rest is not wanted.

### The bug: selecting one facet clears the others

`Filters.update()` replaced the whole facets map instead of merging it.

```js
function mergeState(state = {}, update = {}) {          // merges `facets` per field
  return Object.freeze(trimObj({ ...state, ...update,
    facets: Object.freeze(trimObj({ ...state.facets, ...update.facets })) }));
}

update(updates) {
  this._states = mergeState({ ...oldStates, ...updates });   // ← one argument
}
```

Called with a single pre-spread object, `mergeState`'s second parameter defaults to `{}`, so the per-field merge runs over a map that has already been overwritten wholesale. It never merges.

**The class's own API depends on it merging.** `Facets._unselect` sets one field to `undefined` and relies on the other fields surviving, with `trimObj` dropping the `undefined` to clear this one. Half of that contract worked.

Observed in a browser, two facet fields active:

```
facets.unselect('category_path_depth_1', 'Editorial')
  → facet_filters: null          ← the `type` filter is gone too
```

`<miso-facets>` calls `filters.facets.toggle()` in its own click handler, so **the stock component hits this as soon as a page has two facet fields.** A customer script that always passes a complete selection map is insulated by accident; one that uses the public `facets` API is not.

Four of the six added tests fail without this change.

Both filters held at once, after the fix — a category branch and a `type`, 108 results:

![two facet fields filtered together](https://raw.githubusercontent.com/MisoAI/miso-client-js-sdk/pr-207-screenshots/screenshots/p0-combined-filters.png)

## What else is here

Each of these was a blocker for "represent selected branches of a category tree as individual facets", which is a live customer request.

**Aliased facets could not be rendered.** The response keys `facet_fields` by `alias`, while filtering must use the real field. The layout stamped a single `data-field` and used it for both, so the attribute would have to be the alias to bind and the field to filter. It now reads the definitions the page already declared in `useApi()` and renders `data-key` for binding, `data-field` for filtering, plus an optional `name` for the heading. Binding also reads `data-value` off the element rather than pairing elements to values by DOM order — which nesting breaks.

Five boxes, all reading one category tree, each scoped by its own `include` and titled by `name`:

![several facet boxes from one field](https://raw.githubusercontent.com/MisoAI/miso-client-js-sdk/pr-207-screenshots/screenshots/p1-aliased-facets.png)

**No hierarchy support.** A definition may now declare `hierarchy: { childrenAlias, separator }`; the component nests those values under their parent, renders an expandable row, and does not draw the child alias as a box of its own. Roughly 120 lines of per-customer rendering disappears.

![expandable category hierarchy](https://raw.githubusercontent.com/MisoAI/miso-client-js-sdk/pr-207-screenshots/screenshots/p2-hierarchy-tree.png)

A parent's count covers its children, because a document deep in the tree also appears at the shallower depths. Note `Coronavirus (COVID-19)` — parentheses in a category title are escaped rather than read as a regexp group.

**Two searches on one page did not work.** `client.ui.hybridSearch` is one per client, and `MisoContainerElement` exposes a `workflow` setter for exactly this case — but `connectedCallback` awaited a client and then assigned the default, clobbering the assignment. Before: both tabs showed the same total and a click in one drove the other's query. The flag survives `disconnectedCallback` so a moved container returns to its assigned workflow.

Two searches on one page, each pinned to a content type with its own `fq`, each with its own facet state. Switching between them issues no request:

![first search](https://raw.githubusercontent.com/MisoAI/miso-client-js-sdk/pr-207-screenshots/screenshots/p5-two-searches-tab1.png)
![second search, filtered independently](https://raw.githubusercontent.com/MisoAI/miso-client-js-sdk/pr-207-screenshots/screenshots/p5-two-searches-tab2.png)

**Facet options had no control on them.** They were bare clickable rows, so the selected state was a colour change and nothing said the list was a set of choices. `checkbox: true` on the layout now renders a real input per option — opt-in, so existing pages keep their markup and CSS. A definition may also declare `select: 'single' | 'multiple'`: single renders radios grouped by alias and replaces the value on that field, multiple renders checkboxes and adds to it. `filters.facets.select/toggle` take a per-call `multivalued` override to make that possible; it was previously one setting for every field.

Related, and the reason `facetClassName` never worked either: the base layout keeps only `className` and `templates`, so any other option the templates read was silently dropped. The facets layout now captures its own.

**A hierarchy must come from one field, not one per level.** This was the subtlest of the five, and it produced wrong numbers rather than a visible failure. Deriving the tree from `category_path_depth_1/2/3` puts its filters into several `facet_filters` entries, and:

- entries on different fields **AND** rather than OR, so ticking two categories at different levels intersects them. Measured: `Access rules` 103 documents, `Editorial:::Release notes` 53, both ticked **53** — where a user ticking two boxes expects the union.
- the engine excludes a facet's own field from its counts so the remaining options in that dimension stay comparable. With the dimension spread across fields that exclusion covers only one level, so picking a value at depth 2 silently restated the depth-1 counts: **Editorial 247 → 191, Access rules 103 → 80**.

Read from a single field holding every ancestor path, both are correct: the two selections union to 103, and the counts hold at 247 / 103 / 16. A definition declares `branch` and `hierarchy: { levels, separator }`, and the layout separates the levels itself. `childrenAlias` still works for the one-facet-per-level shape.

**Options accepted and silently ignored now warn.** A `payload` key nested inside the `useApi` payload, and unknown `autoQuery()` options such as passing a query. Both presented identically as "the page renders and nothing happens", and each cost real debugging time.

![the two warnings](https://raw.githubusercontent.com/MisoAI/miso-client-js-sdk/pr-207-screenshots/screenshots/p3-silent-options-now-warn.png)

Also plumbs `filters.facets` options, so `useFilters({ facets: { multivalued: true } })` takes effect. `optionsToState` carried a literal `// TODO: facets` and `Filters` was always constructed as `new Filters(views)`, so `multivalued` was unreachable by any public path.

## Compatibility

The merge change is the only behavioural one. It breaks callers that clear a field by **omitting** it from an otherwise complete map — a pattern that only works because of the bug. Callers that pass a complete map every time are unaffected: merging a complete map over the previous state yields the same result unless a field was dropped.

Worth a scan of the scripts in `MisoAI/distribution` before merging, and a changelog note: **to clear a field, pass `{ [field]: undefined }`** — which is what `_unselect` already does.

Whether this needs a major version is a call for whoever owns release policy. My reading is no, since the pattern it breaks never worked deliberately, but I have deliberately left this as a draft rather than assume.

## Verification

- `npx uvu test` in `packages/client-sdk-ui` — 8 pass; 4 fail if the merge fix is reverted. Adds a `test` script so the workspace runner picks them up; this package had none.
- Built locally and driven in headless Chromium against a real app: several facet boxes reading one tree, branch selection combining with a `type` filter (191 → 108), an expandable tree, and two independent tabbed searches (127 and 53) each scoped by its own `fq`.

## Notes for the reviewer

- The screenshots above sit on the `pr-207-screenshots` orphan branch so this diff stays limited to the source change. They are not part of the merge.

- Facet definitions carry `name` and `hierarchy`, which are client-side only. They currently pass through to the API, which ignores unknown keys. Stripping them before the request would be tidier.
- Building `main` locally produces a bundle whose custom elements never register; building `v1.13.1` is fine. I hit this with and without these changes, so it is not from this branch, but it may be worth a look. This branch is based on `main` and the change is source-only.
- Unrelated, found while debugging the above: when the SDK cannot load its stylesheet it calls `reject()` with no argument, so the failure surfaces as an `undefined` error with no stack and `client.ui.ready` never resolving. A reason string there would save someone an hour.



